### PR TITLE
ci: run docker build workflow on PRs as a dry-run

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
 
 jobs:
   docker:
@@ -16,6 +17,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -30,10 +32,15 @@ jobs:
       - name: Extract version from tag
         id: get_version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+            VERSION=${LAST_TAG}-SNAPSHOT-${GITHUB_SHA:0:7}
+          fi
           MAJOR=$(echo $VERSION | cut -d. -f1)
           MINOR=$(echo $VERSION | cut -d. -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "MAJOR=$MAJOR" >> $GITHUB_OUTPUT
           echo "MAJOR_MINOR=$MAJOR.$MINOR" >> $GITHUB_OUTPUT
 
@@ -45,7 +52,7 @@ jobs:
             docker-compose.yml
             docker-compose.dev.yml
           targets: exporter
-          push: true
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
           set: |
             exporter.tags=ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}
             exporter.tags=ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.MAJOR_MINOR }}


### PR DESCRIPTION
Add a pull_request trigger so the three tag-only Docker actions (setup-buildx, login-action, bake-action) are exercised on every PR, including Dependabot bumps, rather than only at release time.

- fetch-depth: 0 ensures git describe can reach tags for snapshot versioning
- Non-tag runs produce a <last-tag>-SNAPSHOT-<short-sha> version label
- Login runs unconditionally; push is gated on a tag push